### PR TITLE
feat: support spaces and multiline labels

### DIFF
--- a/src/scripts/components/circuitComponent.ts
+++ b/src/scripts/components/circuitComponent.ts
@@ -492,7 +492,7 @@ export abstract class CircuitComponent {
 		// @ts-ignore
 		window.MathJax.texReset()
 		// @ts-ignore
-		return window.MathJax.tex2svgPromise(this.mathJaxLabel.value, {}).then((node: Element) => {
+		return window.MathJax.tex2svgPromise(this.mathJaxLabel.toLatexString(), {}).then((node: Element) => {
 			// mathjax renders the text via an svg container. That container also contains definitions and SVG.Use elements. get that container
 			let svgElement = new SVG.Svg(node.querySelector("svg"))
 

--- a/src/scripts/components/ellipseComponent.ts
+++ b/src/scripts/components/ellipseComponent.ts
@@ -394,7 +394,8 @@ export class EllipseComponent extends ShapeComponent {
 					id + ".center"
 				:	id + "." + this.positionChoice.value.name
 
-			let latexStr = this.mathJaxLabel.value ? "$" + this.mathJaxLabel.value + "$" : ""
+			let rawLabel = this.mathJaxLabel.toLatexString()
+			let latexStr = rawLabel ? "$" + rawLabel + "$" : ""
 			latexStr =
 				latexStr && this.labelColor.value ?
 					"\\textcolor" + this.labelColor.value.toTikzString() + "{" + latexStr + "}"

--- a/src/scripts/components/nodeComponent.ts
+++ b/src/scripts/components/nodeComponent.ts
@@ -232,7 +232,8 @@ export class NodeComponent extends CircuitikzComponent {
 			}
 
 			let posStr = this.positionChoice.value.key == defaultBasicDirection.key ? id + ".text" : id + "." + pos
-			let latexStr = this.mathJaxLabel.value ? "$" + this.mathJaxLabel.value + "$" : ""
+			let rawLabel = this.mathJaxLabel.toLatexString()
+			let latexStr = rawLabel ? "$" + rawLabel + "$" : ""
 			latexStr =
 				latexStr && this.labelColor.value ?
 					"\\textcolor" + this.labelColor.value.toTikzString() + "{" + latexStr + "}"

--- a/src/scripts/components/pathComponent.ts
+++ b/src/scripts/components/pathComponent.ts
@@ -362,7 +362,8 @@ export class PathComponent extends CircuitikzComponent {
 		const scaleFactor =
 			this.scaleProperty.value.value != 1 ? new SVG.Number(this.scaleProperty.value.value * 1.4, "cm") : undefined
 
-		let latexStr = this.mathJaxLabel.value ? "$" + this.mathJaxLabel.value + "$" : ""
+		let rawLabel = this.mathJaxLabel.toLatexString()
+		let latexStr = rawLabel ? "$" + rawLabel + "$" : ""
 		latexStr =
 			latexStr && this.labelColor.value ?
 				"\\textcolor" + this.labelColor.value.toTikzString() + "{" + latexStr + "}"
@@ -373,7 +374,7 @@ export class PathComponent extends CircuitikzComponent {
 			" to[" +
 			this.referenceSymbol.tikzName +
 			(this.name.value === "" ? "" : ", name=" + this.name.value) +
-			(this.mathJaxLabel.value !== "" ?
+			(rawLabel !== "" ?
 				", l" +
 				(this.labelSide.value ? "_" : "") +
 				"={" +

--- a/src/scripts/components/polygonComponent.ts
+++ b/src/scripts/components/polygonComponent.ts
@@ -378,7 +378,8 @@ export class PolygonComponent extends ShapeComponent {
 
 			let posStr = this.textPos.add(labelShift).toTikzString()
 
-			let latexStr = this.mathJaxLabel.value ? "$" + this.mathJaxLabel.value + "$" : ""
+			let rawLabel = this.mathJaxLabel.toLatexString()
+			let latexStr = rawLabel ? "$" + rawLabel + "$" : ""
 			latexStr =
 				latexStr && this.labelColor.value ?
 					"\\textcolor" + this.labelColor.value.toTikzString() + "{" + latexStr + "}"

--- a/src/scripts/components/rectangleComponent.ts
+++ b/src/scripts/components/rectangleComponent.ts
@@ -520,7 +520,8 @@ export class RectangleComponent extends ShapeComponent {
 					id + ".center"
 				:	id + "." + this.positionChoice.value.name
 
-			let latexStr = this.mathJaxLabel.value ? "$" + this.mathJaxLabel.value + "$" : ""
+			let rawLabel = this.mathJaxLabel.toLatexString()
+			let latexStr = rawLabel ? "$" + rawLabel + "$" : ""
 			latexStr =
 				latexStr && this.labelColor.value ?
 					"\\textcolor" + this.labelColor.value.toTikzString() + "{" + latexStr + "}"

--- a/src/scripts/properties/mathjaxProperty.ts
+++ b/src/scripts/properties/mathjaxProperty.ts
@@ -1,7 +1,7 @@
 import { EditableProperty, Undo } from "../internal"
 
 export class MathJaxProperty extends EditableProperty<string> {
-	private input: HTMLInputElement
+	private input: HTMLTextAreaElement
 
 	public constructor(initialValue?: string) {
 		super(initialValue ?? "")
@@ -21,9 +21,8 @@ export class MathJaxProperty extends EditableProperty<string> {
 			formulaSpan1.innerHTML = "$"
 			col.appendChild(formulaSpan1)
 
-			this.input = document.createElement("input") as HTMLInputElement
+			this.input = document.createElement("textarea") as HTMLTextAreaElement
 			this.input.classList.add("form-control")
-			this.input.type = "text"
 			this.input.value = this.value ?? ""
 			col.appendChild(this.input)
 
@@ -53,5 +52,9 @@ export class MathJaxProperty extends EditableProperty<string> {
 		if (this.input) {
 			this.input.value = this.value
 		}
+	}
+
+	public toLatexString(): string {
+		return this.value ? this.value.replaceAll(" ", "\\ ").replaceAll("\n", "\\\\") : ""
 	}
 }


### PR DESCRIPTION
## Summary
- allow MathJax labels to use spaces and line breaks
- generate TikZ using processed labels across components

## Testing
- `npm run lint` *(fails: Code style issues found in 7 files)*

------
https://chatgpt.com/codex/tasks/task_e_689628eabe84832c9f6f26ebc9b05166